### PR TITLE
Bug correction and new features

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # RJDemetra 0.2.8
 
-- Improvement of warning message importing the model when no data in a SaItem.
+- Improvement of warning message importing the model when no data in a SaItem (#61).
 
 - `get_model`, `get_jmodel` and `get_jspec.sa_item` have now an argument `type` to define which specification to import (domain, estimation or point).
 By default the domain specification is extracted (has before).

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,11 @@
 # RJDemetra 0.2.8
 
+- Improvement of warning message importing the model when no data in a SaItem.
+
+- `get_model`, `get_jmodel` and `get_jspec.sa_item` have now an argument `type` to define which specification to import (domain, estimation or point).
+By default the domain specification is extracted (has before).
+
+- Correction of bug of `add_sa_item()` of models created by `jtramoseats()` with external variables.
 
 # RJDemetra 0.2.7
 

--- a/R/export_workspace.R
+++ b/R/export_workspace.R
@@ -96,7 +96,7 @@ full_path <- function(path) {
 #'
 #' @param workspace the workspace to add the seasonally adjusted series to.
 #' @param multiprocessing the name or index of the multiprocessing to add the seasonally adjusted series to.
-#' @param sa_obj the seasonally adjusted object to add
+#' @param sa_obj the seasonally adjusted object to add.
 #' @param name the name of the seasonally adjusted series in the multiprocessing.
 #' By default the name of the \code{sa_obj} is used.
 #'
@@ -164,39 +164,51 @@ complete_dictionary.SA <- function(workspace, sa_obj){
     return(sa_obj)
 
   context_dictionary <- .jcall(workspace,"Lec/tstoolkit/algorithm/ProcessingContext;", "getContext")
-  ts_variable_managers <- context_dictionary$getTsVariableManagers()
+  ts_variable_managers <- .jcall(context_dictionary,"Lec/tstoolkit/utilities/NameManager;", "getTsVariableManagers")
   ts_variables <- .jnew("ec/tstoolkit/timeseries/regression/TsVariables")
-  jd_r_variables <- ts_variable_managers$get("r")
+  jd_r_variables <- .jcall(ts_variable_managers, "Ljava/lang/Object;", "get", "r")
   if (is.null(jd_r_variables)) {
-    ts_variable_managers$set("r",
-                             .jnew("ec/tstoolkit/timeseries/regression/TsVariables"))
-    jd_r_variables <- ts_variable_managers$get("r")
+    .jcall(ts_variable_managers, "V", "set", "r",
+           .jcast(.jnew("ec/tstoolkit/timeseries/regression/TsVariables")))
+    jd_r_variables <- .jcall(ts_variable_managers, "Ljava/lang/Object;", "get", "r")
   }
-  jd_var_names <- jd_r_variables$getNames()
-
+  jd_var_names <- .jcall(jd_r_variables, "[S", "getNames")
   model_var_names <- rownames(ud_var$description)
 
   if (is.mts(ud_var$series)) {
     for (i in seq_along(model_var_names)) {
       name <- model_var_names[i]
-      dictionary_var <- jd_r_variables$get(name)
+      dictionary_var <- .jcall(jd_r_variables, "Ljava/lang/Object;", "get", name)
       tsvar <- .jnew("ec/tstoolkit/timeseries/regression/TsVariable",
                      name, ts_r2jd(ud_var$series[, i]))
       if (is.null(dictionary_var)) {
-        jd_r_variables$set(name, tsvar)
+        .jcall(jd_r_variables, "V", "set", name, .jcast(tsvar, "java/lang/Object"))
       } else {
-        if (!dictionary_var$getTsData()$equals(tsvar$getTsData())) {
-          same_prefix <- grep(paste0("^", name), jd_r_variables$getNames(), value = TRUE)
+        tsvar_ts_data <- .jcall(tsvar, "Lec/tstoolkit/timeseries/simplets/TsData;", "getTsData")
+        if (!.jcall(
+          .jcall(
+            dictionary_var,
+            "Lec/tstoolkit/timeseries/simplets/TsData;", "getTsData"
+          ), "Z", "equals", tsvar_ts_data
+        )) {
+          same_prefix <- grep(paste0("^", name),
+                              .jcall(jd_r_variables, "[S", "getNames"), value = TRUE)
           same_data <- sapply(same_prefix, function(x) {
-            jd_r_variables$get(x)$getTsData()$equals(tsvar$getTsData())
+            .jcall(
+              .jcall(
+              .jcall(jd_r_variables, "Ljava/lang/Object;", "get", x),
+              "Lec/tstoolkit/timeseries/simplets/TsData;", "getTsData"
+            ), "Z", "equals", tsvar_ts_data
+            )
           })
           if (any(same_data)) {
             # a name fix the same prefix  has the same data
             model_new_var_names <- same_prefix[which(same_data)]
           } else {
-            model_new_var_names <-  base::make.unique(c(jd_r_variables$getNames(),
-                                                    name),
-                                                  sep = "_")
+            model_new_var_names <-  base::make.unique(c(
+              .jcall(jd_r_variables, "[S", "getNames"),
+              name),
+              sep = "_")
           }
           model_var_names[i] <- name <- tail(model_new_var_names, 1)
           if (!any(same_data)){
@@ -204,31 +216,45 @@ complete_dictionary.SA <- function(workspace, sa_obj){
             # we create a new one
             tsvar <- .jnew("ec/tstoolkit/timeseries/regression/TsVariable",
                            name, ts_r2jd(ud_var$series[, i]))
-            jd_r_variables$set(name, tsvar)
+            .jcall(jd_r_variables, "V", "set", name, .jcast(tsvar, "java/lang/Object"))
           }
         }
       }
     }
   }else{
     name <- model_var_names
-    dictionary_var <- jd_r_variables$get(name)
+    dictionary_var <- .jcall(jd_r_variables, "Ljava/lang/Object;", "get", name)
     tsvar <- .jnew("ec/tstoolkit/timeseries/regression/TsVariable",
                    name, ts_r2jd(ud_var$series))
     if (is.null(dictionary_var)) {
-      jd_r_variables$set(name, tsvar)
+      .jcall(jd_r_variables, "V", "set", name, .jcast(tsvar, "java/lang/Object"))
     } else {
-      if (!dictionary_var$getTsData()$equals(tsvar$getTsData())) {
-        same_prefix <- grep(paste0("^", name), jd_r_variables$getNames(), value = TRUE)
+      tsvar_ts_data <- .jcall(tsvar, "Lec/tstoolkit/timeseries/simplets/TsData;", "getTsData")
+      if (!.jcall(
+        .jcall(
+          dictionary_var,
+          "Lec/tstoolkit/timeseries/simplets/TsData;", "getTsData"
+        ), "Z", "equals", tsvar_ts_data
+      )) {
+        same_prefix <- grep(paste0("^", name),
+                            .jcall(jd_r_variables, "[S", "getNames"),
+                            value = TRUE)
         same_data <- sapply(same_prefix, function(x) {
-          jd_r_variables$get(x)$getTsData()$equals(tsvar$getTsData())
+          .jcall(
+            .jcall(
+              .jcall(jd_r_variables, "Ljava/lang/Object;", "get", x),
+              "Lec/tstoolkit/timeseries/simplets/TsData;", "getTsData"
+            ), "Z", "equals", tsvar_ts_data
+          )
         })
         if (any(same_data)) {
           # a name fix the same prefix  has the same data
           model_new_var_names <- same_prefix[which(same_data)]
         } else {
-          model_new_var_names <-  base::make.unique(c(jd_r_variables$getNames(),
-                                                  name),
-                                                sep = "_")
+          model_new_var_names <-  base::make.unique(c(
+            .jcall(jd_r_variables, "[S", "getNames"),
+            name),
+            sep = "_")
         }
 
         model_var_names <- name <- tail(model_new_var_names, 1)
@@ -237,7 +263,7 @@ complete_dictionary.SA <- function(workspace, sa_obj){
           # we create a new one
           tsvar <- .jnew("ec/tstoolkit/timeseries/regression/TsVariable",
                          name, ts_r2jd(ud_var$series))
-          jd_r_variables$set(name, tsvar)
+          .jcall(jd_r_variables, "V", "set", name, .jcast(tsvar, "java/lang/Object"))
         }
       }
     }
@@ -251,49 +277,60 @@ complete_dictionary.SA <- function(workspace, sa_obj){
 complete_dictionary.jSA <- function(workspace, sa_obj){
   model_dictionary <- sa_obj$dictionary
   context <- model_dictionary$toContext()
-  current_variables <- context$getTsVariableManagers()$get("r")
+  current_variables <- .jcall(
+    .jcall(context,"Lec/tstoolkit/utilities/NameManager;", "getTsVariableManagers"),
+    "Ljava/lang/Object;", "get", "r"
+  )
   if (is.null(current_variables) || current_variables$getCount() == 0)
     return(sa_obj)
 
   context_dictionary <- .jcall(workspace,"Lec/tstoolkit/algorithm/ProcessingContext;", "getContext")
-  ts_variable_managers <- context_dictionary$getTsVariableManagers()
-  jd_r_variables <- ts_variable_managers$get("r")
+  ts_variable_managers <- .jcall(context_dictionary,"Lec/tstoolkit/utilities/NameManager;", "getTsVariableManagers")
+  jd_r_variables <- .jcall(ts_variable_managers, "Ljava/lang/Object;", "get", "r")
+
   if (is.null(jd_r_variables)) {
-    ts_variable_managers$set("r",
-                             .jnew("ec/tstoolkit/timeseries/regression/TsVariables"))
-    jd_r_variables <- ts_variable_managers$get("r")
+    .jcall(ts_variable_managers, "V", "set", "r",
+           .jcast(.jnew("ec/tstoolkit/timeseries/regression/TsVariables")))
+    jd_r_variables <- .jcall(ts_variable_managers, "Ljava/lang/Object;", "get", "r")
   }
-  variables_names <- data.frame(current_names = current_variables$getNames(),
-             new_names = current_variables$getNames(),
-             stringsAsFactors = FALSE,
-             row.names = current_variables$getNames())
+  variables_names <- data.frame(
+    current_names = .jcall(current_variables, "[S", "getNames"),
+    new_names = .jcall(current_variables, "[S", "getNames"),
+    stringsAsFactors = FALSE,
+    row.names = .jcall(current_variables, "[S", "getNames"))
 
   for (i in seq_len(nrow(variables_names))) {
     name <- variables_names[i,1]
     var <- current_variables$get(name)
-    dictionary_var <- jd_r_variables$get(name)
+    dictionary_var <- .jcall(jd_r_variables, "Ljava/lang/Object;", "get", name)
     if (is.null(dictionary_var)) {
-      jd_r_variables$set(name, var)
+      .jcall(jd_r_variables, "V", "set", name, .jcast(var, "java/lang/Object"))
     } else {
       if (!dictionary_var$getTsData()$equals(var$getTsData())) {
-        same_prefix <- grep(paste0("^", name), jd_r_variables$getNames(), value = TRUE)
+        same_prefix <- grep(paste0("^", name), .jcall(jd_r_variables, "[S", "getNames"), value = TRUE)
         same_data <- sapply(same_prefix, function(x) {
-          jd_r_variables$get(x)$getTsData()$equals(var$getTsData())
+          .jcall(
+            .jcall(
+              .jcall(jd_r_variables, "Ljava/lang/Object;", "get", x),
+              "Lec/tstoolkit/timeseries/simplets/TsData;", "getTsData"
+            ), "Z", "equals", var$getTsData()
+          )
         })
         if (any(same_data)) {
           # a name fix the same prefix  has the same data
           model_var_names <- same_prefix[which(same_data)]
         } else {
-          model_var_names <-  base::make.unique(c(jd_r_variables$getNames(),
-                                                  name),
-                                                sep = "_")
+          model_var_names <-  base::make.unique(c(
+            .jcall(jd_r_variables, "[S", "getNames"),
+            name),
+            sep = "_")
         }
         current_variables$remove(name)
         name <- tail(model_var_names, 1)
         var$setName(name)
-        current_variables$set(name, var)
+        .jcall(current_variables, "V", "set", name, .jcast(var, "java/lang/Object"))
         if (!any(same_data))
-          jd_r_variables$set(name, var)
+          .jcall(jd_r_variables, "V", "set", name, .jcast(var, "java/lang/Object"))
 
         variables_names[i,2] <- name
       }
@@ -304,11 +341,11 @@ complete_dictionary.jSA <- function(workspace, sa_obj){
     return(sa_obj) # no name has been change
 
 
-  core <- sa_obj$spec$getCore()$clone()
+  core <- get_jspec(sa_obj)$clone()
 
   if (.jinstanceof(core, "ec/satoolkit/tramoseats/TramoSeatsSpecification")) {
     core <- .jcast(spec, "ec/satoolkit/tramoseats/TramoSeatsSpecification")
-    spec <- .jnew("jdr/spec/tramoseats/TramoSeatsSpec",core)
+    spec <- .jnew("jdr/spec/tramoseats/TramoSeatsSpec", core)
   }else{
     if (.jinstanceof(core, "ec/satoolkit/x13/X13Specification")) {
       core <- .jcast(core, "ec/satoolkit/x13/X13Specification")

--- a/R/export_workspace.R
+++ b/R/export_workspace.R
@@ -344,7 +344,7 @@ complete_dictionary.jSA <- function(workspace, sa_obj){
   core <- get_jspec(sa_obj)$clone()
 
   if (.jinstanceof(core, "ec/satoolkit/tramoseats/TramoSeatsSpecification")) {
-    core <- .jcast(spec, "ec/satoolkit/tramoseats/TramoSeatsSpecification")
+    core <- .jcast(core, "ec/satoolkit/tramoseats/TramoSeatsSpecification")
     spec <- .jnew("jdr/spec/tramoseats/TramoSeatsSpec", core)
   }else{
     if (.jinstanceof(core, "ec/satoolkit/x13/X13Specification")) {

--- a/R/get_jmodel.R
+++ b/R/get_jmodel.R
@@ -1,15 +1,19 @@
 #' @rdname get_model
 #' @name get_model
 #' @export
-get_jmodel <- function(x, workspace,
-                      userdefined = NULL,
-                      progress_bar = TRUE){
+get_jmodel <- function(
+    x, workspace,
+    userdefined = NULL,
+    progress_bar = TRUE,
+    type = c("Domain", "Estimation", "Point")){
   UseMethod("get_jmodel", x)
 }
 #' @export
-get_jmodel.workspace <- function(x, workspace,
-                                userdefined = NULL,
-                                progress_bar = TRUE){
+get_jmodel.workspace <- function(
+    x, workspace,
+    userdefined = NULL,
+    progress_bar = TRUE,
+    type = c("Domain", "Estimation", "Point")){
   multiprocessings <- get_all_objects(x)
   nb_mp <- length(multiprocessings)
 
@@ -17,17 +21,20 @@ get_jmodel.workspace <- function(x, workspace,
     if (progress_bar)
       cat(sprintf("Multiprocessing %i on %i:\n", i, nb_mp))
     get_jmodel(multiprocessings[[i]],
-              workspace = x, userdefined = userdefined,
-              progress_bar = progress_bar)
+               workspace = x, userdefined = userdefined,
+               progress_bar = progress_bar,
+               type = type)
   })
   names(result) <- names(multiprocessings)
   result
 
 }
 #' @export
-get_jmodel.multiprocessing <- function(x, workspace,
-                                      userdefined = NULL,
-                                      progress_bar = TRUE){
+get_jmodel.multiprocessing <- function(
+    x, workspace,
+    userdefined = NULL,
+    progress_bar = TRUE,
+    type = c("Domain", "Estimation", "Point")){
   all_sa_objects <- get_all_objects(x)
   nb_sa_objs <- length(all_sa_objects)
 
@@ -36,7 +43,8 @@ get_jmodel.multiprocessing <- function(x, workspace,
 
   result <- lapply(seq_len(nb_sa_objs), function(i){
     res <- get_jmodel(all_sa_objects[[i]],
-                     workspace = workspace, userdefined = userdefined)
+                      workspace = workspace, userdefined = userdefined,
+                      type = type)
     if (progress_bar)
       setTxtProgressBar(pb, i)
     res
@@ -47,11 +55,13 @@ get_jmodel.multiprocessing <- function(x, workspace,
   result
 }
 #' @export
-get_jmodel.sa_item <- function(x, workspace,
-                              userdefined = NULL,
-                              progress_bar = TRUE){
+get_jmodel.sa_item <- function(
+    x, workspace,
+    userdefined = NULL,
+    progress_bar = TRUE,
+    type = c("Domain", "Estimation", "Point")){
 
-  jspec <- get_jspec(x)
+  jspec <- get_jspec(x, type = type)
   jresult <- sa_results(x)
   if(is.null(jresult))
     return(NULL)

--- a/R/get_jspec.R
+++ b/R/get_jspec.R
@@ -32,8 +32,8 @@ get_jspec.TRAMO_SEATS <- function(x, ...){
   jspec
 }
 #' @export
-get_jspec.sa_item <- function(x, ...){
-  spec <- sa_spec(x)
+get_jspec.sa_item <- function(x, type = c("Domain", "Estimation", "Point"), ...){
+  spec <- sa_spec(x, type = type)
   if (.jinstanceof(spec, "ec/satoolkit/tramoseats/TramoSeatsSpecification")) {
     spec <- .jcast(spec, "ec/satoolkit/tramoseats/TramoSeatsSpecification")
     spec <- .jnew("jdr/spec/tramoseats/TramoSeatsSpec",spec)

--- a/R/import_workspace.R
+++ b/R/import_workspace.R
@@ -571,14 +571,20 @@ get_model.sa_item <- function(x, workspace,
 # To retrieve the results of an sa_item
 sa_results <- function(jsa) {
   jresult <- .jcall(jsa, "Ljd2/algorithm/IProcResults;", "getResults")
-  if (is.null(jresult))
-    warning("The result of the object is NULL: have you computed the workspace after importing it?\n",
-            "See ?compute for more information.")
+  if (is.null(jresult)) {
+    if (is.null(get_ts(jsa))) {
+      warning("No Data: the result of the object is NULL.")
+    } else {
+      warning("The result of the object is NULL: have you computed the workspace after importing it?\n",
+              "See ?compute for more information.")
+    }
+  }
   return(jresult)
 }
 
 # To retrieve the specifications of a sa_item (possible values for type: Domain, Estimation, Point)
 sa_spec <- function(jsa, type = "Domain") {
+  type <- match.arg(tolower(type), c("domain", "estimation", "point"))
   jt <- .jcall(jsa, "Ljd2/datatypes/sa/SaItemType;", "getSaDefinition")
   if (type == "Domain") {
     return(.jcall(jt, "Lec/satoolkit/ISaSpecification;", "getDomainSpec"))

--- a/R/jsa2r.R
+++ b/R/jsa2r.R
@@ -88,7 +88,7 @@ jSA2R <- function(x, userdefined = NULL){
   jresult <- x[["result"]]@internal
   jspec <- x[["spec"]]
   dictionary <- x[["dictionary"]]
-  context_dictionary <- dictionary$toContext()
+  context_dictionary <- .jcall(dictionary, "Lec/tstoolkit/algorithm/ProcessingContext;", "toContext")
   if(is.null(jresult))
     return(NULL)
 

--- a/R/spec_rjd.R
+++ b/R/spec_rjd.R
@@ -288,20 +288,20 @@ spec_regarima_X13_jd2r <- function(spec = NA, context_dictionary = NULL,
 
   ## Ramp effects
   core_regression <- jregression$getCore()$getRegression()
-  jramps <- core_regression$getRamps()
-  nb_ramps <- core_regression$getRampsCount()
+  jramps <- .jcall(core_regression, "[Lec/tstoolkit/timeseries/regression/Ramp;", "getRamps")
+  nb_ramps <- .jcall(core_regression, "I", "getRampsCount")
   if (nb_ramps > 0) {
-    var_names <- sapply(seq_len(nb_ramps), function(x) jramps[[x]]$getDescription())
+    var_names <- sapply(jramps, .jcall, "S", "getDescription")
 
     result$userdef_spec$specification$variables <-
       TRUE
 
     coeff <- NA
-    if (core_regression$hasFixedCoefficients()) {
+    if (.jcall(core_regression, "Z", "hasFixedCoefficients")) {
       coeff <- sapply(seq_len(nb_ramps), function(i){
         jramp <- jramps[[i]]
-        ramp_name <- jramp$getName()
-        fixed_coeff <- core_regression$getFixedCoefficients(ramp_name)
+        ramp_name <- .jcall(jramp, "S", "getName")
+        fixed_coeff <- .jcall(core_regression, "[D", "getFixedCoefficients", ramp_name)
         if (is.null(fixed_coeff)) {
           NA
         }else{
@@ -331,11 +331,13 @@ spec_regarima_X13_jd2r <- function(spec = NA, context_dictionary = NULL,
         end_ts <- end(result$userdef_spec$variables$series)
         ramp_series <- lapply(seq_len(nb_ramps), function(i){
           jramp <- jramps[[i]]
-          jstart <- jramp$getStart()
-          jend <- jramp$getEnd()
+          jstart <- .jcall(jramp, "Lec/tstoolkit/timeseries/Day;", "getStart")
+          jend <- .jcall(jramp, "Lec/tstoolkit/timeseries/Day;", "getEnd")
 
-          start_ramp <- c(jstart$getYear(), jstart$getMonth())
-          end_ramp <- c(jend$getYear(), jend$getMonth())
+          start_ramp <- c(.jcall(jstart, "I", "getYear"),
+                          .jcall(jstart, "I", "getMonth"))
+          end_ramp <- c(.jcall(jend, "I", "getYear"),
+                        .jcall(jend, "I", "getMonth"))
           ramp(start = start_ts, end = end_ts,
                start_ramp = start_ramp, end_ramp = end_ramp,
                frequency = freq)
@@ -343,11 +345,13 @@ spec_regarima_X13_jd2r <- function(spec = NA, context_dictionary = NULL,
       } else {
         ramp_series <- lapply(seq_len(nb_ramps), function(i){
           jramp <- jramps[[i]]
-          jstart <- jramp$getStart()
-          jend <- jramp$getEnd()
+          jstart <- .jcall(jramp, "Lec/tstoolkit/timeseries/Day;", "getStart")
+          jend <- .jcall(jramp, "Lec/tstoolkit/timeseries/Day;", "getEnd")
 
-          start_ramp <- c(jstart$getYear(), jstart$getMonth())
-          end_ramp <- c(jend$getYear(), jend$getMonth())
+          start_ramp <- c(.jcall(jstart, "I", "getYear"),
+                          .jcall(jstart, "I", "getMonth"))
+          end_ramp <- c(.jcall(jend, "I", "getYear"),
+                        .jcall(jend, "I", "getMonth"))
           ramp(start_ramp = start_ramp, end_ramp = end_ramp,
                frequency = freq)
         })
@@ -356,7 +360,13 @@ spec_regarima_X13_jd2r <- function(spec = NA, context_dictionary = NULL,
                         start = start(ramp_series[[1]]),
                         frequency = frequency(ramp_series[[1]]))
       if (!identical_na(result$userdef_spec$variables$series)) {
-        ramp_series <- ts.union(result$userdef_spec$variables$series, ramp_series)
+        if (frequency (result$userdef_spec$variables$series) != frequency(ramp_series)){
+          # here we assume that the seris in result$userdef_spec$variables$series are wrong and are then deleted
+          # e.g calendar regressors defined in spec monthly while the input ts is quarterly
+          ramp_series <- ramp_series
+        } else {
+          ramp_series <- ts.union(result$userdef_spec$variables$series, ramp_series)
+        }
       }
       if (is.mts(ramp_series))
         colnames(ramp_series) <- rownames(result$userdef_spec$variables$description)
@@ -624,8 +634,8 @@ spec_TRAMO_jd2r <- function(spec = NA, context_dictionary = NULL,
     # if (core_regression$hasFixedCoefficients()) {
     #   # coeff <- sapply(seq_len(nb_ramps), function(i){
     #   #   jramp <- jramps[[i]]
-    #   #   ramp_name <- jramp$getName()
-    #   #   fixed_coeff <- core_regression$getFixedCoefficients(ramp_name)
+    #   #   ramp_name <- .jcall(jramp, "S", "getName")
+    #   #   fixed_coeff <- .jcall(core_regression, "[D", "getFixedCoefficients", ramp_name)
     #   #   if (is.null(fixed_coeff)) {
     #   #     NA
     #   #   }else{
@@ -668,10 +678,10 @@ spec_TRAMO_jd2r <- function(spec = NA, context_dictionary = NULL,
 
   ## Ramp effects
   core_regression <- jregression$getCore()$getRegression()
-  jramps <- core_regression$getRamps()
-  nb_ramps <- core_regression$getRampsCount()
+  jramps <- .jcall(core_regression, "[Lec/tstoolkit/timeseries/regression/Ramp;", "getRamps")
+  nb_ramps <- .jcall(core_regression, "I", "getRampsCount")
   if (nb_ramps > 0) {
-    var_names <- sapply(seq_len(nb_ramps), function(x) jramps[[x]]$getDescription())
+    var_names <- sapply(jramps, .jcall, "S", "getDescription")
 
     result$userdef_spec$specification$variables <-
       TRUE
@@ -679,8 +689,8 @@ spec_TRAMO_jd2r <- function(spec = NA, context_dictionary = NULL,
     if (.jcall(core_regression, "Z", "hasFixedCoefficients")) {
       coeff <- sapply(seq_len(nb_ramps), function(i){
         jramp <- jramps[[i]]
-        ramp_name <- jramp$getName()
-        fixed_coeff <- core_regression$getFixedCoefficients(ramp_name)
+        ramp_name <- .jcall(jramp, "S", "getName")
+        fixed_coeff <- .jcall(core_regression, "[D", "getFixedCoefficients", ramp_name)
         if (is.null(fixed_coeff)) {
           NA
         }else{
@@ -710,11 +720,13 @@ spec_TRAMO_jd2r <- function(spec = NA, context_dictionary = NULL,
         end_ts <- end(result$userdef_spec$variables$series)
         ramp_series <- lapply(seq_len(nb_ramps), function(i){
           jramp <- jramps[[i]]
-          jstart <- jramp$getStart()
-          jend <- jramp$getEnd()
+          jstart <- .jcall(jramp, "Lec/tstoolkit/timeseries/Day;", "getStart")
+          jend <- .jcall(jramp, "Lec/tstoolkit/timeseries/Day;", "getEnd")
 
-          start_ramp <- c(jstart$getYear(), jstart$getMonth())
-          end_ramp <- c(jend$getYear(), jend$getMonth())
+          start_ramp <- c(.jcall(jstart, "I", "getYear"),
+                          .jcall(jstart, "I", "getMonth"))
+          end_ramp <- c(.jcall(jend, "I", "getYear"),
+                        .jcall(jend, "I", "getMonth"))
           ramp(start = start_ts, end = end_ts,
                start_ramp = start_ramp, end_ramp = end_ramp,
                frequency = freq)
@@ -722,11 +734,13 @@ spec_TRAMO_jd2r <- function(spec = NA, context_dictionary = NULL,
       } else {
         ramp_series <- lapply(seq_len(nb_ramps), function(i){
           jramp <- jramps[[i]]
-          jstart <- jramp$getStart()
-          jend <- jramp$getEnd()
+          jstart <- .jcall(jramp, "Lec/tstoolkit/timeseries/Day;", "getStart")
+          jend <- .jcall(jramp, "Lec/tstoolkit/timeseries/Day;", "getEnd")
 
-          start_ramp <- c(jstart$getYear(), jstart$getMonth())
-          end_ramp <- c(jend$getYear(), jend$getMonth())
+          start_ramp <- c(.jcall(jstart, "I", "getYear"),
+                          .jcall(jstart, "I", "getMonth"))
+          end_ramp <- c(.jcall(jend, "I", "getYear"),
+                        .jcall(jend, "I", "getMonth"))
           ramp(start_ramp = start_ramp, end_ramp = end_ramp,
                frequency = freq)
         })
@@ -735,7 +749,13 @@ spec_TRAMO_jd2r <- function(spec = NA, context_dictionary = NULL,
                        start = start(ramp_series[[1]]),
                        frequency = frequency(ramp_series[[1]]))
       if (!identical_na(result$userdef_spec$variables$series)) {
-        ramp_series <- ts.union(result$userdef_spec$variables$series, ramp_series)
+        if (frequency (result$userdef_spec$variables$series) != frequency(ramp_series)){
+          # here we assume that the seris in result$userdef_spec$variables$series are wrong and are then deleted
+          # e.g calendar regressors defined in spec monthly while the input ts is quarterly
+          ramp_series <- ramp_series
+        } else {
+          ramp_series <- ts.union(result$userdef_spec$variables$series, ramp_series)
+        }
       }
       if (is.mts(ramp_series))
         colnames(ramp_series) <- rownames(result$userdef_spec$variables$description)
@@ -881,8 +901,9 @@ preVar_r2jd <- function(jsobjct = NA, jsdict = NA, coefEna = NA,
     if(n_calendar_def == 1){
       .jcall(jsdict,"V","add",varNames,ts_r2jd(series))
       if(coef!=0){
-        jcoreg$setFixedCoefficients(paste0("td|r@",varNames),
-                                    .jarray(coef))
+        .jcall(jcoreg, "V", "setFixedCoefficients",
+               paste0("td|r@",varNames),
+               .jarray(coef))
       }
       .jcall(jtd,"V","setUserVariables", .jarray(paste0("r.",varNames)))
 
@@ -898,8 +919,9 @@ preVar_r2jd <- function(jsobjct = NA, jsdict = NA, coefEna = NA,
         for (i in 1:nvar){
           .jcall(jsdict,"V","add",varNames[i],ts_r2jd(series[,i]))
           if(coef[i]!=0){
-            jcoreg$setFixedCoefficients(paste0("td|r@",varNames[i]),
-                                        .jarray(coef[i]))
+            .jcall(jcoreg, "V", "setFixedCoefficients",
+                   paste0("td|r@",varNames[i]),
+                   .jarray(coef[i]))
           }
         }
         .jcall(jtd,"V","setUserVariables",
@@ -925,8 +947,9 @@ preVar_r2jd <- function(jsobjct = NA, jsdict = NA, coefEna = NA,
         .jcall(jsdict,"V","add",varNames[i],
                ts_r2jd(series[, i]))
         if(coef[i]!=0){
-          jcoreg$setFixedCoefficients(paste0("td|r@",varNames[i]),
-                                      .jarray(coef[i]))
+          .jcall(jcoreg, "V", "setFixedCoefficients",
+                 paste0("td|r@",varNames[i]),
+                 .jarray(coef[i]))
         }
       }
       .jcall(jtd,"V","setUserVariables",

--- a/R/spec_rjd.R
+++ b/R/spec_rjd.R
@@ -17,7 +17,7 @@ spec_regarima_X13_jd2r <- function(spec = NA, context_dictionary = NULL,
                          freq = NA){
 
   #Estimate
-  preliminary.check <- spec$getBasic()$isPreliminaryCheck()
+  preliminary.check <- .jcall(.jcall(spec, "Ljdr/spec/x13/BasicSpec;" ,"getBasic"), "Z", "isPreliminaryCheck")
 
   jestimate <-.jcall(spec,"Ljdr/spec/x13/EstimateSpec;","getEstimate")
   jest.span <-.jcall(jestimate,"Ljdr/spec/ts/SpanSelector;","getSpan")
@@ -173,9 +173,9 @@ spec_regarima_X13_jd2r <- function(spec = NA, context_dictionary = NULL,
              "getPrespecifiedOutlier",
              as.integer(i-1))
     })
-    type <- sapply(outliers, function(x) x$getCode())
-    date <- sapply(outliers, function(x) x$getPosition())
-    coeff <- sapply(outliers, function(x) x$getCoefficient())
+    type <- sapply(outliers, .jcall, "S", "getCode")
+    date <- sapply(outliers, .jcall, "S", "getPosition")
+    coeff <- sapply(outliers, .jcall, "D", "getCoefficient")
     if(all(coeff == 0)){ #All coefficients are equal to 0: they are not fixed
       result$userdef_spec$specification$outlier.coef <- FALSE
       coeff <- coeff * NA
@@ -200,9 +200,9 @@ spec_regarima_X13_jd2r <- function(spec = NA, context_dictionary = NULL,
              as.integer(i-1))
     })
 
-    type <- sapply(ud_vars, function(x) x$getComponent())
-    coeff <- sapply(ud_vars, function(x) x$getCoefficient())
-    var_names <- sapply(ud_vars, function(x) x$getName())
+    type <- sapply(ud_vars, .jcall, "S", "getComponent")
+    coeff <- sapply(ud_vars, .jcall, "D", "getCoefficient")
+    var_names <- sapply(ud_vars, .jcall, "S", "getName")
     var_names_split <- strsplit(var_names,"[.]")
     var_names <- sapply(var_names_split, function(x) x[2])
     var_names <- base::make.names(var_names, unique = TRUE)
@@ -226,9 +226,12 @@ spec_regarima_X13_jd2r <- function(spec = NA, context_dictionary = NULL,
     if(!is.null(context_dictionary)){
 
       var_series <- lapply(var_names_split,function(names){
-        ts_variable <- context_dictionary$getTsVariable(names[1],
-                                                         names[2])
-        ts_jd2r(ts_variable$getTsData())
+        ts_variable <- .jcall(context_dictionary,
+                              "Lec/tstoolkit/timeseries/regression/ITsVariable;",
+                              "getTsVariable",
+                              names[1],
+                              names[2])
+        ts_jd2r(.jcall(ts_variable, "Lec/tstoolkit/timeseries/simplets/TsData;", "getTsData"))
       })
       var_series <- ts(simplify2array(var_series),
                        start = start(var_series[[1]]), frequency = frequency(var_series[[1]]))
@@ -242,7 +245,7 @@ spec_regarima_X13_jd2r <- function(spec = NA, context_dictionary = NULL,
   }
 
   #Calendar
-  user_td <- jtd$getUserVariables()
+  user_td <- .jcall(jtd, "[S", "getUserVariables")
   if(length(user_td) > 0 ){
     var_names_split <- strsplit(user_td,"[.]")
     var_names <- sapply(var_names_split, function(x) x[2])
@@ -264,9 +267,12 @@ spec_regarima_X13_jd2r <- function(spec = NA, context_dictionary = NULL,
     if(!is.null(context_dictionary)){
 
       var_series <- lapply(var_names_split,function(names){
-        ts_variable <- context_dictionary$getTsVariable(names[1],
-                                                         names[2])
-        ts_jd2r(ts_variable$getTsData())
+        ts_variable <- .jcall(context_dictionary,
+                              "Lec/tstoolkit/timeseries/regression/ITsVariable;",
+                              "getTsVariable",
+                              names[1],
+                              names[2])
+        ts_jd2r(.jcall(ts_variable, "Lec/tstoolkit/timeseries/simplets/TsData;", "getTsData"))
       })
       var_series <- ts(simplify2array(var_series),
                        start = start(var_series[[1]]), frequency = frequency(var_series[[1]]))
@@ -359,10 +365,10 @@ spec_regarima_X13_jd2r <- function(spec = NA, context_dictionary = NULL,
     }
   }
 
-  Phi <- jarima$getPhi()
-  BPhi <- jarima$getBPhi()
-  Theta <- jarima$getTheta()
-  BTheta <- jarima$getBTheta()
+  Phi <- .jcall(jarima,"[Lec/tstoolkit/Parameter;","getPhi")
+  BPhi <- .jcall(jarima,"[Lec/tstoolkit/Parameter;","getBPhi")
+  Theta <- .jcall(jarima,"[Lec/tstoolkit/Parameter;","getTheta")
+  BTheta <- .jcall(jarima,"[Lec/tstoolkit/Parameter;","getBTheta")
   arima_coefficients_spec <-
     rbind(arimaCoef_jd2r(Phi),
           arimaCoef_jd2r(BPhi),
@@ -382,7 +388,7 @@ spec_TRAMO_jd2r <- function(spec = NA, context_dictionary = NULL,
                        extra_info = FALSE, freq = NA){
 
   #Estimate
-  preliminary.check <- spec$getBasic()$isPreliminaryCheck()
+  preliminary.check <- .jcall(.jcall(spec, "Ljdr/spec/tramoseats/BasicSpec;" ,"getBasic"), "Z", "isPreliminaryCheck")
   jestimate <- .jcall(spec,"Ljdr/spec/tramoseats/EstimateSpec;","getEstimate")
   jest.span <- .jcall(jestimate,"Ljdr/spec/ts/SpanSelector;","getSpan")
 
@@ -534,9 +540,9 @@ spec_TRAMO_jd2r <- function(spec = NA, context_dictionary = NULL,
              "getPrespecifiedOutlier",
              as.integer(i-1))
     })
-    type <- sapply(outliers, function(x) x$getCode())
-    date <- sapply(outliers, function(x) x$getPosition())
-    coeff <- sapply(outliers, function(x) x$getCoefficient())
+    type <- sapply(outliers, .jcall, "S", "getCode")
+    date <- sapply(outliers, .jcall, "S", "getPosition")
+    coeff <- sapply(outliers, .jcall, "D", "getCoefficient")
 
     if(all(coeff == 0)){ #All coefficients are equal to 0: they are not fixed
       result$userdef_spec$specification$outlier.coef <- FALSE
@@ -564,9 +570,9 @@ spec_TRAMO_jd2r <- function(spec = NA, context_dictionary = NULL,
              as.integer(i-1))
     })
 
-    type <- sapply(ud_vars, function(x) x$getComponent())
-    coeff <- sapply(ud_vars, function(x) x$getCoefficient())
-    var_names <- sapply(ud_vars, function(x) x$getName())
+    type <- sapply(ud_vars, .jcall, "S", "getComponent")
+    coeff <- sapply(ud_vars, .jcall, "D", "getCoefficient")
+    var_names <- sapply(ud_vars, .jcall, "S", "getName")
     var_names_split <- strsplit(var_names,"[.]")
     var_names <- sapply(var_names_split, function(x) x[2])
 
@@ -588,9 +594,12 @@ spec_TRAMO_jd2r <- function(spec = NA, context_dictionary = NULL,
     if(!is.null(context_dictionary)){
 
       var_series <- lapply(var_names_split,function(names){
-        ts_variable <- context_dictionary$getTsVariable(names[1],
-                                                         names[2])
-        ts_jd2r(ts_variable$getTsData())
+        ts_variable <- .jcall(context_dictionary,
+                              "Lec/tstoolkit/timeseries/regression/ITsVariable;",
+                              "getTsVariable",
+                              names[1],
+                              names[2])
+        ts_jd2r(.jcall(ts_variable, "Lec/tstoolkit/timeseries/simplets/TsData;", "getTsData"))
       })
       var_series <- ts(simplify2array(var_series),
                        start = start(var_series[[1]]), frequency = frequency(var_series[[1]]))
@@ -604,7 +613,7 @@ spec_TRAMO_jd2r <- function(spec = NA, context_dictionary = NULL,
   }
 
   #Calendar
-  user_td <- jtd$getUserVariables()
+  user_td <- .jcall(jtd, "[S", "getUserVariables")
   if(length(user_td) > 0 ){
     var_names_split <- strsplit(user_td,"[.]")
     var_names <- sapply(var_names_split, function(x) x[2])
@@ -638,9 +647,12 @@ spec_TRAMO_jd2r <- function(spec = NA, context_dictionary = NULL,
     if(!is.null(context_dictionary)){
 
       var_series <- lapply(var_names_split,function(names){
-        ts_variable <- context_dictionary$getTsVariable(names[1],
-                                                         names[2])
-        ts_jd2r(ts_variable$getTsData())
+        ts_variable <- .jcall(context_dictionary,
+                              "Lec/tstoolkit/timeseries/regression/ITsVariable;",
+                              "getTsVariable",
+                              names[1],
+                              names[2])
+        ts_jd2r(.jcall(ts_variable, "Lec/tstoolkit/timeseries/simplets/TsData;", "getTsData"))
       })
       var_series <- ts(simplify2array(var_series),
                        start = start(var_series[[1]]), frequency = frequency(var_series[[1]]))
@@ -664,7 +676,7 @@ spec_TRAMO_jd2r <- function(spec = NA, context_dictionary = NULL,
     result$userdef_spec$specification$variables <-
       TRUE
     coeff <- NA
-    if (core_regression$hasFixedCoefficients()) {
+    if (.jcall(core_regression, "Z", "hasFixedCoefficients")) {
       coeff <- sapply(seq_len(nb_ramps), function(i){
         jramp <- jramps[[i]]
         ramp_name <- jramp$getName()
@@ -733,10 +745,10 @@ spec_TRAMO_jd2r <- function(spec = NA, context_dictionary = NULL,
   }
 
   #Arima
-  Phi <- jarima$getPhi()
-  BPhi <- jarima$getBPhi()
-  Theta <- jarima$getTheta()
-  BTheta <- jarima$getBTheta()
+  Phi <- .jcall(jarima,"[Lec/tstoolkit/Parameter;","getPhi")
+  BPhi <- .jcall(jarima,"[Lec/tstoolkit/Parameter;","getBPhi")
+  Theta <- .jcall(jarima,"[Lec/tstoolkit/Parameter;","getTheta")
+  BTheta <- .jcall(jarima,"[Lec/tstoolkit/Parameter;","getBTheta")
   arima_coefficients_spec <-
     rbind(arimaCoef_jd2r(Phi),
           arimaCoef_jd2r(BPhi),
@@ -776,7 +788,9 @@ specX11_jd2r <- function(spec = NA, freq = NA){
   fcasts <- .jcall(jx11,"I","getForecastHorizon")
   bcasts <- .jcall(jx11,"I","getBackcastHorizon")
   excludeFcasts <- .jcall(jx11,"Z","isExcludefcst")
-  calendarSigma <- jx11$getCalendarSigma()$toString()
+  calendarSigma <- .jcall(
+    .jcall(jx11, "Lec/satoolkit/x11/CalendarSigma;", "getCalendarSigma"),
+    "S", "toString")
   sigmaVector <- .jcall(jx11,returnSig = "[S", "getSigmavec") #TODO
   if (length(sigmaVector) == 0) {
     sigmaVector <- NA
@@ -960,8 +974,8 @@ arimaCoef_jd2r <- function(jparams){
   if (len==0)
     return (NULL)
   param_name <- deparse(substitute(jparams))
-  Type <- sapply(param, function(x) x$getType()$toString())
-  Value <- sapply(param, function(x) x$getValue())
+  Type <- sapply(param, function(x) .jcall(.jcall(x, "Lec/tstoolkit/ParameterType;" , "getType"), "S", "toString"))
+  Value <- sapply(param, .jcall, "D", "getValue")
   data_param <- data.frame(Type = Type, Value = Value)
   rownames(data_param) <- sprintf("%s(%i)",
                                   param_name,
@@ -991,7 +1005,7 @@ spec_regarima_X13_r2jd <- function(spec = NA, jdspec = NA){
             n0 = as.integer(span[1,4]), n1=as.integer(span[1,5]))
   .jcall(jestimate ,"V","setTol", as.numeric(est["tolerance"]))
 
-  jdspec$getBasic()$setPreliminaryCheck(est[1, "preliminary.check"])
+  .jcall(.jcall(jdspec, "Ljdr/spec/x13/BasicSpec;" ,"getBasic"), "V", "setPreliminaryCheck", est[1, "preliminary.check"])
 
   #Transform
   jtransform <-.jcall(jdspec,"Ljdr/spec/x13/TransformSpec;","getTransform")
@@ -1110,7 +1124,7 @@ spec_TRAMO_r2jd <- function(spec = NA, jdspec =NA){
   span <- s_span(spec)
 
   #Estimate
-  jdspec$getBasic()$setPreliminaryCheck(est[1, "preliminary.check"])
+  .jcall(.jcall(jdspec, "Ljdr/spec/tramoseats/BasicSpec;" ,"getBasic"), "V", "setPreliminaryCheck", est[1, "preliminary.check"])
 
   jestimate <-.jcall(jdspec,"Ljdr/spec/tramoseats/EstimateSpec;","getEstimate")
 

--- a/R/tramoseats.R
+++ b/R/tramoseats.R
@@ -150,11 +150,14 @@ tramoseats.SA_spec <- function(series, spec,
   }else{
 
     # Error during the preliminary check
-    res = jrslt$getResults()$getProcessingInformation()
+    proc_info <- .jcall(
+      .jcall(jrslt,
+             "Lec/tstoolkit/algorithm/CompositeResults;", "getResults"
+      ),
+      "Ljava/util/List;", "getProcessingInformation"
+    )
 
-    if(is.null(jrslt$getDiagnostics()) & !.jcall(res,"Z","isEmpty")){
-      proc_info <- jrslt$getResults()$getProcessingInformation()
-
+    if(is.null(.jcall(jrslt,"Lec/tstoolkit/jdr/sa/SaDiagnostics;", "getDiagnostics")) & !.jcall(proc_info,"Z","isEmpty")){
       error_msg <- .jcall(proc_info, "Ljava/lang/Object;", "get", 0L)$getErrorMessages(proc_info)
       warning_msg <- .jcall(proc_info, "Ljava/lang/Object;", "get", 0L)$getWarningMessages(proc_info)
       if(!.jcall(error_msg,"Z","isEmpty"))
@@ -199,10 +202,14 @@ tramoseatsJavaResults <- function(jrslt, spec,
     return(NaN)
 
   # Error in preliminary check
-  res = jrslt$getResults()$getProcessingInformation()
+  proc_info <- .jcall(
+    .jcall(jrslt,
+           "Lec/tstoolkit/algorithm/CompositeResults;", "getResults"
+    ),
+    "Ljava/util/List;", "getProcessingInformation"
+  )
 
-  if(is.null(jrslt$getDiagnostics()) & !.jcall(res,"Z","isEmpty")){
-    proc_info <- jrslt$getResults()$getProcessingInformation()
+  if(is.null(.jcall(jrslt,"Lec/tstoolkit/jdr/sa/SaDiagnostics;", "getDiagnostics")) & !.jcall(proc_info,"Z","isEmpty")){
     error_msg <- .jcall(proc_info, "Ljava/lang/Object;", "get", 0L)$getErrorMessages(proc_info)
     warning_msg <- .jcall(proc_info, "Ljava/lang/Object;", "get", 0L)$getWarningMessages(proc_info)
     if(!.jcall(error_msg,"Z","isEmpty"))

--- a/R/tramoseats.R
+++ b/R/tramoseats.R
@@ -161,9 +161,9 @@ tramoseats.SA_spec <- function(series, spec,
       error_msg <- .jcall(proc_info, "Ljava/lang/Object;", "get", 0L)$getErrorMessages(proc_info)
       warning_msg <- .jcall(proc_info, "Ljava/lang/Object;", "get", 0L)$getWarningMessages(proc_info)
       if(!.jcall(error_msg,"Z","isEmpty"))
-        stop(error_msg$toString())
+        stop(.jcall(error_msg, "S", "toString"))
       if(!.jcall(warning_msg,"Z","isEmpty"))
-        warning(warning_msg$toString())
+        warning(.jcall(warning_msg, "S", "toString"))
     }
     reg <- regarima_TS(jrobj = jrobct_arima, spec = spec$regarima)
     deco <- decomp_TS(jrobj = jrobct, spec = spec$seats)
@@ -213,9 +213,9 @@ tramoseatsJavaResults <- function(jrslt, spec,
     error_msg <- .jcall(proc_info, "Ljava/lang/Object;", "get", 0L)$getErrorMessages(proc_info)
     warning_msg <- .jcall(proc_info, "Ljava/lang/Object;", "get", 0L)$getWarningMessages(proc_info)
     if(!.jcall(error_msg,"Z","isEmpty"))
-      stop(error_msg$toString())
+      stop(.jcall(error_msg, "S", "toString"))
     if(!.jcall(warning_msg,"Z","isEmpty"))
-      warning(warning_msg$toString())
+      warning(.jcall(warning_msg, "S", "toString"))
   }
 
   reg <- regarima_defTS(jrobj = jrobct_arima, spec = spec,

--- a/R/x13.R
+++ b/R/x13.R
@@ -146,10 +146,14 @@ x13.SA_spec <- function(series, spec, userdefined = NULL){
     return(NaN)
   }else{
     # Error with the preliminary check
-    res = jrslt$getResults()$getProcessingInformation()
+    proc_info <- .jcall(
+      .jcall(jrslt,
+             "Lec/tstoolkit/algorithm/CompositeResults;", "getResults"
+      ),
+      "Ljava/util/List;", "getProcessingInformation"
+    )
 
-    if(is.null(jrslt$getDiagnostics()) & !.jcall(res,"Z","isEmpty")){
-      proc_info <- jrslt$getResults()$getProcessingInformation()
+    if(is.null(.jcall(jrslt,"Lec/tstoolkit/jdr/sa/SaDiagnostics;", "getDiagnostics")) & !.jcall(proc_info,"Z","isEmpty")){
       error_msg <- .jcall(proc_info, "Ljava/lang/Object;", "get", 0L)$getErrorMessages(proc_info)
       warning_msg <- .jcall(proc_info, "Ljava/lang/Object;", "get", 0L)$getWarningMessages(proc_info)
       if(!.jcall(error_msg,"Z","isEmpty"))
@@ -195,9 +199,13 @@ x13JavaResults <- function(jrslt, spec, userdefined = NULL,
   }
 
   # Error during the preliminary check
-  res = jrslt$getResults()$getProcessingInformation()
-  if(is.null(jrslt$getDiagnostics()) & !.jcall(res,"Z","isEmpty")){
-    proc_info <- jrslt$getResults()$getProcessingInformation()
+  proc_info <- .jcall(
+    .jcall(jrslt,
+           "Lec/tstoolkit/algorithm/CompositeResults;", "getResults"
+    ),
+    "Ljava/util/List;", "getProcessingInformation"
+  )
+  if(is.null(.jcall(jrslt,"Lec/tstoolkit/jdr/sa/SaDiagnostics;", "getDiagnostics")) & !.jcall(proc_info,"Z","isEmpty")){
     error_msg <- .jcall(proc_info, "Ljava/lang/Object;", "get", 0L)$getErrorMessages(proc_info)
     warning_msg <- .jcall(proc_info, "Ljava/lang/Object;", "get", 0L)$getWarningMessages(proc_info)
     if(!.jcall(error_msg,"Z","isEmpty"))

--- a/R/x13.R
+++ b/R/x13.R
@@ -157,9 +157,9 @@ x13.SA_spec <- function(series, spec, userdefined = NULL){
       error_msg <- .jcall(proc_info, "Ljava/lang/Object;", "get", 0L)$getErrorMessages(proc_info)
       warning_msg <- .jcall(proc_info, "Ljava/lang/Object;", "get", 0L)$getWarningMessages(proc_info)
       if(!.jcall(error_msg,"Z","isEmpty"))
-        stop(error_msg$toString())
+        stop(.jcall(error_msg, "S", "toString"))
       if(!.jcall(warning_msg,"Z","isEmpty"))
-        warning(warning_msg$toString())
+        warning(.jcall(warning_msg, "S", "toString"))
     }
     reg <- regarima_X13(jrobj = jrobct_arima, spec = spec$regarima)
     deco <- decomp_X13(jrobj = jrobct, spec = spec$x11, seasma = seasma)
@@ -209,9 +209,9 @@ x13JavaResults <- function(jrslt, spec, userdefined = NULL,
     error_msg <- .jcall(proc_info, "Ljava/lang/Object;", "get", 0L)$getErrorMessages(proc_info)
     warning_msg <- .jcall(proc_info, "Ljava/lang/Object;", "get", 0L)$getWarningMessages(proc_info)
     if(!.jcall(error_msg,"Z","isEmpty"))
-      stop(error_msg$toString())
+      stop(.jcall(error_msg, "S", "toString"))
     if(!.jcall(warning_msg,"Z","isEmpty"))
-      warning(warning_msg$toString())
+      warning(.jcall(warning_msg, "S", "toString"))
   }
 
   reg <- regarima_defX13(jrobj = jrobct_arima, spec = spec,

--- a/man/add_sa_item.Rd
+++ b/man/add_sa_item.Rd
@@ -11,7 +11,7 @@ add_sa_item(workspace, multiprocessing, sa_obj, name)
 
 \item{multiprocessing}{the name or index of the multiprocessing to add the seasonally adjusted series to.}
 
-\item{sa_obj}{the seasonally adjusted object to add}
+\item{sa_obj}{the seasonally adjusted object to add.}
 
 \item{name}{the name of the seasonally adjusted series in the multiprocessing.
 By default the name of the \code{sa_obj} is used.}

--- a/man/get_model.Rd
+++ b/man/get_model.Rd
@@ -5,9 +5,21 @@
 \alias{get_jmodel}
 \title{Get the seasonally adjusted model from a workspace}
 \usage{
-get_jmodel(x, workspace, userdefined = NULL, progress_bar = TRUE)
+get_jmodel(
+  x,
+  workspace,
+  userdefined = NULL,
+  progress_bar = TRUE,
+  type = c("Domain", "Estimation", "Point")
+)
 
-get_model(x, workspace, userdefined = NULL, progress_bar = TRUE)
+get_model(
+  x,
+  workspace,
+  userdefined = NULL,
+  progress_bar = TRUE,
+  type = c("Domain", "Estimation", "Point")
+)
 }
 \arguments{
 \item{x}{the object from which to retrieve the seasonally adjusted model.}
@@ -18,6 +30,8 @@ get_model(x, workspace, userdefined = NULL, progress_bar = TRUE)
 (see \code{\link{x13}} or \code{\link{tramoseats}}).}
 
 \item{progress_bar}{Boolean: if \code{TRUE}, a progress bar is printed.}
+
+\item{type}{a \code{character} indicating the type of model to retrieve: `"Domain"` (initial specification), `"Estimation"` (specification used for the current estimation) or "Point" (specification corresponding to the results of the current estimation: fully identified model).}
 }
 \value{
 \code{get_model()} returns a seasonally adjusted object (class \code{c("SA", "X13")} or \code{c("SA", "TRAMO_SEATS"}) or a list of seasonally adjusted objects:


### PR DESCRIPTION
- Improvement of warning message importing the model when no data in a SaItem (#61).

- `get_model`, `get_jmodel` and `get_jspec.sa_item` have now an argument `type` to define which specification to import (domain, estimation or point).
By default the domain specification is extracted (has before).

- Correction of bug of `add_sa_item()` of models created by `jtramoseats()` with external variables.

- reduce use of reflection in Java calls